### PR TITLE
Use hyperspy-base instead of hyperspy as runtime dependency.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
 
@@ -27,7 +27,7 @@ requirements:
   run:
     - python >=3.5
     - link-traits
-    - hyperspy >=1.4
+    - hyperspy-base
     - ipywidgets >=6.0
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

Same as https://github.com/conda-forge/hyperspy-gui-traitsui-feedstock/pull/8.